### PR TITLE
Fund treasury proposal implementation (both cli and keeper)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -658,13 +658,9 @@ func (app *OnomyApp) RegisterTendermintService(clientCtx client.Context) {
 	tmservice.RegisterTendermintService(app.BaseApp.GRPCQueryRouter(), clientCtx, app.interfaceRegistry)
 }
 
-// GetMaccPerms returns a copy of the module account permissions.
-func GetMaccPerms() map[string][]string {
-	dupMaccPerms := make(map[string][]string)
-	for k, v := range maccPerms {
-		dupMaccPerms[k] = v
-	}
-	return dupMaccPerms
+// SetOrderEndBlockers sets the order of set end-blocker calls.
+func (app *OnomyApp) SetOrderEndBlockers(moduleNames ...string) {
+	app.mm.SetOrderEndBlockers(moduleNames...)
 }
 
 // initParamsKeeper init params keeper and its subspaces.

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/onomyprotocol/tm-load-test v0.9.1-0.20211101093435-b38e68e11c01
 	github.com/spf13/cast v1.4.1
 	github.com/spf13/cobra v1.2.1
+	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/testify v1.7.0
 	github.com/tendermint/starport v0.19.3
 	github.com/tendermint/tendermint v0.34.14

--- a/testutil/network/network.go
+++ b/testutil/network/network.go
@@ -4,46 +4,65 @@ package network
 import (
 	"fmt"
 	"testing"
-	"time"
 
-	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
-	"github.com/cosmos/cosmos-sdk/crypto/hd"
-	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	"github.com/cosmos/cosmos-sdk/client/flags"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
-	"github.com/cosmos/cosmos-sdk/simapp"
-	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	"github.com/cosmos/cosmos-sdk/testutil/network"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/stretchr/testify/require"
 	"github.com/tendermint/starport/starport/pkg/cosmoscmd"
-	tmrand "github.com/tendermint/tendermint/libs/rand"
-	tmdb "github.com/tendermint/tm-db"
 
 	"github.com/onomyprotocol/onomy/app"
+	"github.com/onomyprotocol/onomy/testutil/simapp"
 )
 
 type (
 	Network = network.Network // nolint:revive // simapp test var
 	Config  = network.Config  // nolint:revive // simapp test var
-	// TestNetwork defines the test network wrapper.
-	TestNetwork struct {
-		*network.Network
-	}
 )
 
-// SetupNetwork setups the test network.
-func SetupNetwork(t *testing.T) *TestNetwork {
+// TestNetwork defines the test network wrapper.
+type TestNetwork struct {
+	*network.Network
+}
+
+// New setups the test network.
+func New(t *testing.T) *TestNetwork {
 	t.Helper()
 
-	onomyNetwork := New(t)
+	cfg := network.DefaultConfig()
 
-	_, err := onomyNetwork.WaitForHeight(1)
-	if err != nil {
-		panic(err)
+	cfg.NumValidators = 1
+	encCfg := cosmoscmd.MakeEncodingConfig(app.ModuleBasics)
+	cfg.GenesisState = app.ModuleBasics.DefaultGenesis(encCfg.Marshaler)
+	cfg.AppConstructor = func(val network.Validator) servertypes.Application {
+		onomyApp := simapp.Setup(true)
+		// the override is required in order not to face the issue with the gravity end blocker validation
+		// because it requires the eth address to be linked with the validator account
+		onomyApp.SetOrderEndBlockers(crisistypes.ModuleName, govtypes.ModuleName, stakingtypes.ModuleName)
+		return onomyApp
 	}
 
+	onomyNetwork := network.New(t, cfg)
+
+	_, err := onomyNetwork.WaitForHeight(1)
+	require.NoError(t, err)
+
 	return &TestNetwork{onomyNetwork}
+}
+
+// TxValidator1Args returns the tx params for the 1s network validator.
+func (testNetwork *TestNetwork) TxValidator1Args() []string {
+	return []string{
+		fmt.Sprintf("--%s=%s", flags.FlagFrom, testNetwork.Validators[0].Address.String()),
+		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
+		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(testNetwork.Config.BondDenom, sdk.NewInt(10))).String()), // nolint:gomnd //test constant
+		fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
+	}
 }
 
 // Validator1Ctx returns the context of the 1st validator in the network.
@@ -54,58 +73,4 @@ func (testNetwork *TestNetwork) Validator1Ctx() client.Context {
 // Validator1Address returns the address of the 1st validator in the network.
 func (testNetwork *TestNetwork) Validator1Address() sdk.AccAddress {
 	return testNetwork.Validators[0].Address
-}
-
-// New creates instance with fully configured cosmos network.
-// Accepts optional config, that will be used in place of the DefaultConfig() if provided.
-func New(t *testing.T, configs ...network.Config) *network.Network {
-	t.Helper()
-
-	if len(configs) > 1 {
-		panic("at most one config should be provided")
-	}
-	var cfg network.Config
-	if len(configs) == 0 {
-		cfg = DefaultConfig()
-	} else {
-		cfg = configs[0]
-	}
-	net := network.New(t, cfg)
-	t.Cleanup(net.Cleanup)
-	return net
-}
-
-// DefaultConfig will initialize config for the network with custom application,
-// genesis and single validator. All other parameters are inherited from cosmos-sdk/testutil/network.DefaultConfig.
-func DefaultConfig() network.Config {
-	encoding := cosmoscmd.MakeEncodingConfig(app.ModuleBasics)
-	return network.Config{
-		Codec:             encoding.Marshaler,
-		TxConfig:          encoding.TxConfig,
-		LegacyAmino:       encoding.Amino,
-		InterfaceRegistry: encoding.InterfaceRegistry,
-		AccountRetriever:  authtypes.AccountRetriever{},
-		AppConstructor: func(val network.Validator) servertypes.Application {
-			return app.New(
-				val.Ctx.Logger, tmdb.NewMemDB(), nil, true, map[int64]bool{}, val.Ctx.Config.RootDir, 0,
-				encoding,
-				simapp.EmptyAppOptions{},
-				baseapp.SetPruning(storetypes.NewPruningOptionsFromString(val.AppConfig.Pruning)),
-				baseapp.SetMinGasPrices(val.AppConfig.MinGasPrices),
-			)
-		},
-		GenesisState:    app.ModuleBasics.DefaultGenesis(encoding.Marshaler),
-		TimeoutCommit:   2 * time.Second,                    // nolint:gomnd // simapp param
-		ChainID:         "chain-" + tmrand.NewRand().Str(6), // nolint:gomnd // simapp param
-		NumValidators:   3,                                  // nolint:gomnd // default validators number
-		BondDenom:       sdk.DefaultBondDenom,
-		MinGasPrices:    fmt.Sprintf("0.000006%s", sdk.DefaultBondDenom),
-		AccountTokens:   sdk.TokensFromConsensusPower(1000000000000000, sdk.DefaultPowerReduction), // nolint:gomnd // simapp param
-		StakingTokens:   sdk.TokensFromConsensusPower(500000000000000, sdk.DefaultPowerReduction),  // nolint:gomnd // simapp param
-		BondedTokens:    sdk.TokensFromConsensusPower(100000000000000, sdk.DefaultPowerReduction),  // nolint:gomnd // simapp param
-		PruningStrategy: storetypes.PruningOptionNothing,
-		CleanupDir:      true,
-		SigningAlgo:     string(hd.Secp256k1Type),
-		KeyringOptions:  []keyring.Option{},
-	}
 }

--- a/x/dao/client/cli/query_test.go
+++ b/x/dao/client/cli/query_test.go
@@ -30,7 +30,8 @@ func TestCLI_ShowTreasury(t *testing.T) {
 	} {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			testNetwork := network.SetupNetwork(t)
+			testNetwork := network.New(t)
+			defer testNetwork.Cleanup()
 
 			if tt.prep != nil {
 				tt.prep(testNetwork)

--- a/x/dao/client/cli/tx.go
+++ b/x/dao/client/cli/tx.go
@@ -6,10 +6,22 @@ import (
 	"strings"
 
 	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/tx"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/version"
+	govcli "github.com/cosmos/cosmos-sdk/x/gov/client/cli"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"github.com/onomyprotocol/onomy/x/dao/types"
 )
+
+type proposalGeneric struct {
+	Title       string
+	Description string
+	Deposit     string
+}
 
 // GetTxCmd returns the transaction commands for this module.
 func GetTxCmd() *cobra.Command {
@@ -21,24 +33,65 @@ func GetTxCmd() *cobra.Command {
 		RunE:                       client.ValidateCmd,
 	}
 
+	cmd.AddCommand(CmdFundTreasuryProposal())
+	cmd.AddCommand(CmdExchangeWithTreasuryProposal())
+
 	return cmd
 }
 
-// GetCmdFundTreasuryProposalHandler implements the command to submit a fund-treasury proposal.
-func GetCmdFundTreasuryProposalHandler() *cobra.Command {
-	return &cobra.Command{
-		Use:   "fund-treasury",
+// CmdFundTreasuryProposal implements the command to submit a fund-treasury proposal.
+func CmdFundTreasuryProposal() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "fund-treasury amount",
 		Args:  cobra.ExactArgs(1),
-		Short: "Submit a fund treasury proposal.",
-		Long:  strings.TrimSpace(""),
+		Short: "Submit a fund treasury proposal",
+		Long: strings.TrimSpace(
+			fmt.Sprintf(`Submit a fund spend treasury along with an initial deposit.
+Example:
+$ %s tx gov submit-proposal fund-treasury 5000000000000000000anom --title="Test Proposal" --description="My awesome proposal" --deposit="1000000000000000000anom" --from mykey`,
+				version.AppName,
+			),
+		),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return nil
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			amount, err := sdk.ParseCoinsNormalized(args[0])
+			if err != nil {
+				return err
+			}
+
+			proposalGeneric, err := parseSubmitProposalFlags(cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			deposit, err := sdk.ParseCoinsNormalized(proposalGeneric.Deposit)
+			if err != nil {
+				return err
+			}
+
+			from := clientCtx.GetFromAddress()
+			content := types.NewFundTreasuryProposal(from, proposalGeneric.Title, proposalGeneric.Description, amount)
+
+			msg, err := govtypes.NewMsgSubmitProposal(content, deposit, from)
+			if err != nil {
+				return err
+			}
+
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}
+
+	addProposalFlags(cmd)
+
+	return cmd
 }
 
-// GetCmdExchangeWithTreasuryProposalHandler implements the command to submit a exchange-with-treasury proposal.
-func GetCmdExchangeWithTreasuryProposalHandler() *cobra.Command {
+// CmdExchangeWithTreasuryProposal implements the command to submit a exchange-with-treasury proposal.
+func CmdExchangeWithTreasuryProposal() *cobra.Command {
 	return &cobra.Command{
 		Use:   "exchange-with-treasury",
 		Args:  cobra.ExactArgs(1),
@@ -48,4 +101,32 @@ func GetCmdExchangeWithTreasuryProposalHandler() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+func addProposalFlags(cmd *cobra.Command) {
+	cmd.Flags().String(govcli.FlagTitle, "", "The proposal title")
+	cmd.Flags().String(govcli.FlagDescription, "", "The proposal description")
+	cmd.Flags().String(govcli.FlagDeposit, "", "The proposal deposit")
+}
+
+func parseSubmitProposalFlags(fs *pflag.FlagSet) (*proposalGeneric, error) {
+	title, err := fs.GetString(govcli.FlagTitle)
+	if err != nil {
+		return nil, err
+	}
+	description, err := fs.GetString(govcli.FlagDescription)
+	if err != nil {
+		return nil, err
+	}
+
+	deposit, err := fs.GetString(govcli.FlagDeposit)
+	if err != nil {
+		return nil, err
+	}
+
+	return &proposalGeneric{
+		Title:       title,
+		Description: description,
+		Deposit:     deposit,
+	}, nil
 }

--- a/x/dao/client/cli/tx_test.go
+++ b/x/dao/client/cli/tx_test.go
@@ -1,0 +1,61 @@
+package cli_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	clitestutil "github.com/cosmos/cosmos-sdk/testutil/cli"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onomyprotocol/onomy/testutil/network"
+	"github.com/onomyprotocol/onomy/x/dao/client/cli"
+)
+
+const (
+	normalToken = "node0token"
+	stakeToken  = "stake"
+)
+
+func TestCLI_FundTreasuryProposal(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		args string
+		err  error
+		code uint32
+	}{
+		{
+			name: "positive",
+			args: fmt.Sprintf("5000000000000000000%s --title=Title --description=Description --deposit=1000000000000000000%s", normalToken, stakeToken),
+		},
+		{
+			name: "negative_insufficient_balance",
+			args: fmt.Sprintf("5000000000000000000%s --title=Title --description=Description --deposit=1000000000000000000%s", "newcoin", stakeToken),
+			code: govtypes.ErrInvalidProposalContent.ABCICode(),
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			testNetwork := network.New(t)
+			defer testNetwork.Cleanup()
+			args := strings.Split(tt.args, " ")
+			args = append(args, testNetwork.TxValidator1Args()...)
+			ctx := testNetwork.Validator1Ctx()
+			// on the onomy chain those flag will be added ny the gov module
+			cmd := cli.CmdFundTreasuryProposal()
+			flags.AddTxFlagsToCmd(cmd)
+			out, err := clitestutil.ExecTestCLICmd(ctx, cmd, args)
+			if tt.err != nil {
+				require.ErrorIs(t, err, tt.err)
+			} else {
+				require.NoError(t, err)
+				var resp sdk.TxResponse
+				require.NoError(t, testNetwork.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+				require.Equal(t, tt.code, resp.Code, fmt.Sprintf("%+v", resp))
+			}
+		})
+	}
+}

--- a/x/dao/client/proposal_handler.go
+++ b/x/dao/client/proposal_handler.go
@@ -14,9 +14,9 @@ import (
 
 var (
 	// FundTreasuryProposalHandler is the cli handler used for the gov cli integration.
-	FundTreasuryProposalHandler = govclient.NewProposalHandler(cli.GetCmdFundTreasuryProposalHandler, emptyRestHandler) // nolint:gochecknoglobals // cosmos-sdk style
+	FundTreasuryProposalHandler = govclient.NewProposalHandler(cli.CmdFundTreasuryProposal, emptyRestHandler) // nolint:gochecknoglobals // cosmos-sdk style
 	// ExchangeWithTreasuryProposalProposalHandler is the cli handler used for the gov cli integration.
-	ExchangeWithTreasuryProposalProposalHandler = govclient.NewProposalHandler(cli.GetCmdExchangeWithTreasuryProposalHandler, emptyRestHandler) // nolint:gochecknoglobals // cosmos-sdk style
+	ExchangeWithTreasuryProposalProposalHandler = govclient.NewProposalHandler(cli.CmdExchangeWithTreasuryProposal, emptyRestHandler) // nolint:gochecknoglobals // cosmos-sdk style
 )
 
 func emptyRestHandler(client.Context) govrest.ProposalRESTHandler {

--- a/x/dao/genesis_test.go
+++ b/x/dao/genesis_test.go
@@ -5,6 +5,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
 	"github.com/onomyprotocol/onomy/testutil/simapp"
 	"github.com/onomyprotocol/onomy/x/dao"
@@ -35,7 +36,8 @@ func TestInitGenesis(t *testing.T) {
 	}
 	for _, tt := range tests {
 		tt := tt
-		app, ctx := simapp.Setup()
+		app := simapp.Setup(false)
+		ctx := app.BaseApp.NewContext(false, tmproto.Header{})
 		t.Run(tt.name, func(t *testing.T) {
 			dao.InitGenesis(ctx, app.DaoKeeper, tt.args.genState)
 			exportedModuleBalance := app.BankKeeper.GetAllBalances(ctx, app.AccountKeeper.GetModuleAddress(types.ModuleName))
@@ -68,7 +70,8 @@ func TestInitAndExportGenesis(t *testing.T) {
 	}
 	for _, tt := range tests {
 		tt := tt
-		app, ctx := simapp.Setup()
+		app := simapp.Setup(false)
+		ctx := app.BaseApp.NewContext(false, tmproto.Header{})
 		t.Run(tt.name, func(t *testing.T) {
 			dao.InitGenesis(ctx, app.DaoKeeper, tt.args.genState)
 			exportedGenesis := dao.ExportGenesis(ctx, app.DaoKeeper)

--- a/x/dao/keeper/grpc_query_test.go
+++ b/x/dao/keeper/grpc_query_test.go
@@ -5,6 +5,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
 	"github.com/onomyprotocol/onomy/testutil/simapp"
 	"github.com/onomyprotocol/onomy/x/dao/types"
@@ -38,7 +39,8 @@ func TestKeeper_Treasury(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			app, ctx := simapp.Setup()
+			app := simapp.Setup(false)
+			ctx := app.BaseApp.NewContext(false, tmproto.Header{})
 			wctx := sdk.WrapSDKContext(ctx)
 			app.DaoKeeper.InitGenesis(ctx, types.GenesisState{
 				TreasuryBalance: tt.args.treasuryBalance,

--- a/x/dao/keeper/proposal.go
+++ b/x/dao/keeper/proposal.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	"github.com/onomyprotocol/onomy/x/dao/types"
 )
@@ -10,7 +11,18 @@ var _ types.QueryServer = Keeper{}
 
 // FundTreasuryProposal submits the FundTreasuryProposal.
 func (k Keeper) FundTreasuryProposal(ctx sdk.Context, request *types.FundTreasuryProposal) error {
-	return nil
+	senderAddr, err := sdk.AccAddressFromBech32(request.Sender)
+	if err != nil {
+		return err
+	}
+
+	senderBalance := k.bankKeeper.GetAllBalances(ctx, senderAddr)
+	amountToSend := request.Amount
+	if _, isNegative := senderBalance.SafeSub(amountToSend); isNegative {
+		return sdkerrors.Wrapf(types.ErrInsufficientBalance, "sender balance is less than amount to send")
+	}
+
+	return k.bankKeeper.SendCoinsFromAccountToModule(ctx, senderAddr, types.ModuleName, amountToSend)
 }
 
 // ExchangeWithTreasuryProposal submits the ExchangeWithTreasuryProposal.

--- a/x/dao/keeper/proposal_test.go
+++ b/x/dao/keeper/proposal_test.go
@@ -1,0 +1,111 @@
+package keeper_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/stretchr/testify/require"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+
+	"github.com/onomyprotocol/onomy/testutil/simapp"
+	"github.com/onomyprotocol/onomy/x/dao/types"
+)
+
+func TestKeeper_FundTreasuryProposal(t *testing.T) {
+	const (
+		denom1 = "denom1"
+		denom2 = "denom2"
+	)
+
+	account := simapp.GenAccount()
+
+	type args struct {
+		accountBalance sdk.Coins
+		sender         string
+		amount         sdk.Coins
+	}
+
+	tests := []struct {
+		name                string
+		args                args
+		wantTreasuryBalance sdk.Coins
+		wantErr             error
+	}{
+		{
+			name: "positive_one_coin_full",
+			args: args{
+				accountBalance: sdk.NewCoins(sdk.NewInt64Coin(denom1, 10)),
+				sender:         account.String(),
+				amount:         sdk.NewCoins(sdk.NewInt64Coin(denom1, 10)),
+			},
+			wantTreasuryBalance: sdk.NewCoins(sdk.NewInt64Coin(denom1, 10)),
+		},
+		{
+			name: "positive_one_coin_partial",
+			args: args{
+				accountBalance: sdk.NewCoins(sdk.NewInt64Coin(denom1, 10)),
+				sender:         account.String(),
+				amount:         sdk.NewCoins(sdk.NewInt64Coin(denom1, 5)),
+			},
+			wantTreasuryBalance: sdk.NewCoins(sdk.NewInt64Coin(denom1, 5)),
+		},
+		{
+			name: "positive_two_coins_partial",
+			args: args{
+				accountBalance: sdk.NewCoins(sdk.NewInt64Coin(denom1, 10), sdk.NewInt64Coin(denom2, 8)),
+				sender:         account.String(),
+				amount:         sdk.NewCoins(sdk.NewInt64Coin(denom1, 5), sdk.NewInt64Coin(denom2, 8)),
+			},
+			wantTreasuryBalance: sdk.NewCoins(sdk.NewInt64Coin(denom1, 5), sdk.NewInt64Coin(denom2, 8)),
+		},
+		{
+			name: "negative_insufficient_balance",
+			args: args{
+				accountBalance: sdk.NewCoins(sdk.NewInt64Coin(denom1, 10)),
+				sender:         account.String(),
+				amount:         sdk.NewCoins(sdk.NewInt64Coin(denom1, 11)),
+			},
+			wantErr: sdkerrors.Wrapf(types.ErrInsufficientBalance, "sender balance is less than amount to send"),
+		},
+		{
+			name: "negative_not_existing_token",
+			args: args{
+				accountBalance: sdk.NewCoins(sdk.NewInt64Coin(denom1, 10)),
+				sender:         account.String(),
+				amount:         sdk.NewCoins(sdk.NewInt64Coin(denom2, 10)),
+			},
+			wantErr: sdkerrors.Wrapf(types.ErrInsufficientBalance, "sender balance is less than amount to send"),
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			app := simapp.Setup(false)
+			ctx := app.BaseApp.NewContext(false, tmproto.Header{})
+			wctx := sdk.WrapSDKContext(ctx)
+			require.NoError(t, app.BankKeeper.MintCoins(ctx, types.ModuleName, tt.args.accountBalance))
+
+			senderAddr, err := sdk.AccAddressFromBech32(tt.args.sender)
+			require.NoError(t, err)
+			require.NoError(t, app.BankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, senderAddr, tt.args.accountBalance))
+
+			err = app.DaoKeeper.FundTreasuryProposal(ctx, &types.FundTreasuryProposal{
+				Sender: tt.args.sender,
+				Amount: tt.args.amount,
+			})
+
+			if tt.wantErr != nil {
+				require.Equal(t, tt.wantErr.Error(), err.Error())
+				return
+			}
+
+			require.NoError(t, err)
+
+			got, err := app.DaoKeeper.Treasury(wctx, &types.QueryTreasuryRequest{})
+			require.NoError(t, err)
+
+			require.Equal(t, tt.wantTreasuryBalance, got.TreasuryBalance)
+		})
+	}
+}

--- a/x/dao/types/codec.go
+++ b/x/dao/types/codec.go
@@ -1,16 +1,26 @@
 package types
 
 import (
+	"fmt"
+
 	"github.com/cosmos/cosmos-sdk/codec"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 )
 
 // RegisterCodec registers the legacy amino codec.
 func RegisterCodec(cdc *codec.LegacyAmino) {
+	cdc.RegisterConcrete(&FundTreasuryProposal{}, fmt.Sprintf("%s/%s", ModuleName, ProposalTypeFundTreasuryProposal), nil)
+	cdc.RegisterConcrete(&ExchangeWithTreasuryProposal{}, fmt.Sprintf("%s/%s", ModuleName, ProposalTypeExchangeWithTreasuryProposal), nil)
 }
 
 // RegisterInterfaces registers the cdctypes interface.
 func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
+	registry.RegisterImplementations(
+		(*govtypes.Content)(nil),
+		&FundTreasuryProposal{},
+		&ExchangeWithTreasuryProposal{},
+	)
 }
 
 var (

--- a/x/dao/types/errors.go
+++ b/x/dao/types/errors.go
@@ -1,1 +1,6 @@
 package types
+
+import sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+
+// ErrInsufficientBalance - the user balance is insufficient for the operation.
+var ErrInsufficientBalance = sdkerrors.Register(ModuleName, 1, "insufficient balance")

--- a/x/dao/types/expected_keepers.go
+++ b/x/dao/types/expected_keepers.go
@@ -15,5 +15,6 @@ type BankKeeper interface {
 	GetAllBalances(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins
 	SendCoinsFromModuleToAccount(ctx sdk.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
 	SendCoinsFromModuleToModule(ctx sdk.Context, senderModule, recipientModule string, amt sdk.Coins) error
+	SendCoinsFromAccountToModule(ctx sdk.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
 	MintCoins(ctx sdk.Context, name string, amt sdk.Coins) error
 }

--- a/x/dao/types/proposal.go
+++ b/x/dao/types/proposal.go
@@ -17,7 +17,10 @@ const (
 )
 
 // Assert FundTreasuryProposal implements govtypes.Content at compile-time.
-var _ govtypes.Content = &FundTreasuryProposal{}
+var (
+	_ govtypes.Content = &FundTreasuryProposal{}
+	_ govtypes.Content = &ExchangeWithTreasuryProposal{}
+)
 
 func init() { // nolint:gochecknoinits // cosmos sdk style
 	govtypes.RegisterProposalType(ProposalTypeFundTreasuryProposal)

--- a/x/dao/types/proposal_test.go
+++ b/x/dao/types/proposal_test.go
@@ -1,0 +1,60 @@
+package types_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/onomyprotocol/onomy/testutil/simapp"
+	"github.com/onomyprotocol/onomy/x/dao/types"
+)
+
+func TestFundTreasuryProposal_ValidateBasic(t *testing.T) {
+	const denom1 = "denom1"
+
+	type fields struct {
+		Sender      string
+		Title       string
+		Description string
+		Amount      sdk.Coins
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			name: "positive",
+			fields: fields{
+				Sender:      simapp.GenAccount().String(),
+				Title:       "title",
+				Description: "desc",
+				Amount:      sdk.NewCoins(sdk.NewInt64Coin(denom1, 10)),
+			},
+		},
+		{
+			name: "negative_invalid_sender",
+			fields: fields{
+				Sender:      "invalid-sender",
+				Title:       "title",
+				Description: "desc",
+				Amount:      sdk.NewCoins(sdk.NewInt64Coin(denom1, 10)),
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			m := &types.FundTreasuryProposal{
+				Sender:      tt.fields.Sender,
+				Title:       tt.fields.Title,
+				Description: tt.fields.Description,
+				Amount:      tt.fields.Amount,
+			}
+			if err := m.ValidateBasic(); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateBasic() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fund treasury proposal implementation (both CLI and keeper).
The "fund treasury proposal" is fully integrated with the gov module, so it is possible to create/cancel the "fund treasury proposal" via CLI or RPC and pass it through the voting.
A user can specify the amount to be funded alongside the proposal deposit. In case the proposal is accepted the funding will be accepted and coins will be sent from the user's account o the treasury.