### PR TITLE
DAO module extract grpc query server from keeper

### DIFF
--- a/x/dao/keeper/grpc_query.go
+++ b/x/dao/keeper/grpc_query.go
@@ -10,24 +10,34 @@ import (
 	"github.com/onomyprotocol/onomy/x/dao/types"
 )
 
-var _ types.QueryServer = Keeper{}
+// QueryServer is keep wrapper which provides query capabilities.
+type QueryServer struct {
+	keeper Keeper
+}
+
+// NewQueryServer creates a new instance of QueryServer.
+func NewQueryServer(keeper Keeper) *QueryServer {
+	return &QueryServer{
+		keeper: keeper,
+	}
+}
+
+var _ types.QueryServer = QueryServer{}
 
 // Params return dao module current params values.
-func (k Keeper) Params(c context.Context, req *types.QueryParamsRequest) (*types.QueryParamsResponse, error) {
+func (q QueryServer) Params(c context.Context, req *types.QueryParamsRequest) (*types.QueryParamsResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}
 	ctx := sdk.UnwrapSDKContext(c)
 
-	return &types.QueryParamsResponse{Params: k.GetParams(ctx)}, nil
+	return &types.QueryParamsResponse{Params: q.keeper.GetParams(ctx)}, nil
 }
 
 // Treasury returns the treasury balance.
-func (k Keeper) Treasury(c context.Context, _ *types.QueryTreasuryRequest) (*types.QueryTreasuryResponse, error) {
+func (q QueryServer) Treasury(c context.Context, _ *types.QueryTreasuryRequest) (*types.QueryTreasuryResponse, error) {
 	ctx := sdk.UnwrapSDKContext(c)
-	daoAddress := k.accountKeeper.GetModuleAddress(types.ModuleName)
-	daoBalance := k.bankKeeper.GetAllBalances(ctx, daoAddress)
 	return &types.QueryTreasuryResponse{
-		TreasuryBalance: daoBalance,
+		TreasuryBalance: q.keeper.Treasury(ctx),
 	}, nil
 }

--- a/x/dao/keeper/proposal.go
+++ b/x/dao/keeper/proposal.go
@@ -7,8 +7,6 @@ import (
 	"github.com/onomyprotocol/onomy/x/dao/types"
 )
 
-var _ types.QueryServer = Keeper{}
-
 // FundTreasuryProposal submits the FundTreasuryProposal.
 func (k Keeper) FundTreasuryProposal(ctx sdk.Context, request *types.FundTreasuryProposal) error {
 	senderAddr, err := sdk.AccAddressFromBech32(request.Sender)

--- a/x/dao/keeper/proposal_test.go
+++ b/x/dao/keeper/proposal_test.go
@@ -83,7 +83,6 @@ func TestKeeper_FundTreasuryProposal(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			app := simapp.Setup(false)
 			ctx := app.BaseApp.NewContext(false, tmproto.Header{})
-			wctx := sdk.WrapSDKContext(ctx)
 			require.NoError(t, app.BankKeeper.MintCoins(ctx, types.ModuleName, tt.args.accountBalance))
 
 			senderAddr, err := sdk.AccAddressFromBech32(tt.args.sender)
@@ -102,10 +101,8 @@ func TestKeeper_FundTreasuryProposal(t *testing.T) {
 
 			require.NoError(t, err)
 
-			got, err := app.DaoKeeper.Treasury(wctx, &types.QueryTreasuryRequest{})
-			require.NoError(t, err)
-
-			require.Equal(t, tt.wantTreasuryBalance, got.TreasuryBalance)
+			got := app.DaoKeeper.Treasury(ctx)
+			require.Equal(t, tt.wantTreasuryBalance, got)
 		})
 	}
 }
@@ -262,7 +259,6 @@ func TestKeeper_ExchangeWithTreasuryProposal(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			app := simapp.Setup(false)
 			ctx := app.BaseApp.NewContext(false, tmproto.Header{})
-			wctx := sdk.WrapSDKContext(ctx)
 
 			require.NoError(t, app.BankKeeper.MintCoins(ctx, types.ModuleName, tt.args.treasuryBalance))
 			require.NoError(t, app.BankKeeper.MintCoins(ctx, types.ModuleName, tt.args.accountBalance))
@@ -280,9 +276,8 @@ func TestKeeper_ExchangeWithTreasuryProposal(t *testing.T) {
 				return
 			}
 
-			got, err := app.DaoKeeper.Treasury(wctx, &types.QueryTreasuryRequest{})
-			require.NoError(t, err)
-			require.Equal(t, tt.wantTreasuryBalance, got.TreasuryBalance)
+			got := app.DaoKeeper.Treasury(ctx)
+			require.Equal(t, tt.wantTreasuryBalance, got)
 
 			senderBalance := app.BankKeeper.GetAllBalances(ctx, senderAddr)
 			require.Equal(t, tt.wantAccountBalance, senderBalance)

--- a/x/dao/keeper/treasury.go
+++ b/x/dao/keeper/treasury.go
@@ -1,0 +1,13 @@
+package keeper
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/onomyprotocol/onomy/x/dao/types"
+)
+
+// Treasury returns the treasury balance.
+func (k Keeper) Treasury(ctx sdk.Context) sdk.Coins {
+	daoAddress := k.accountKeeper.GetModuleAddress(types.ModuleName)
+	return k.bankKeeper.GetAllBalances(ctx, daoAddress)
+}

--- a/x/dao/keeper/treasury_test.go
+++ b/x/dao/keeper/treasury_test.go
@@ -24,16 +24,14 @@ func TestKeeper_Treasury(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
-		want *types.QueryTreasuryResponse
+		want sdk.Coins
 	}{
 		{
 			name: "get_from_genesis",
 			args: args{
 				treasuryBalance: sdk.NewCoins(sdk.NewInt64Coin(denom1, 1), sdk.NewInt64Coin(denom2, 2)),
 			},
-			want: &types.QueryTreasuryResponse{
-				TreasuryBalance: sdk.NewCoins(sdk.NewInt64Coin(denom1, 1), sdk.NewInt64Coin(denom2, 2)),
-			},
+			want: sdk.NewCoins(sdk.NewInt64Coin(denom1, 1), sdk.NewInt64Coin(denom2, 2)),
 		},
 	}
 	for _, tt := range tests {
@@ -41,15 +39,14 @@ func TestKeeper_Treasury(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			app := simapp.Setup(false)
 			ctx := app.BaseApp.NewContext(false, tmproto.Header{})
-			wctx := sdk.WrapSDKContext(ctx)
+
 			err := app.DaoKeeper.InitGenesis(ctx, types.GenesisState{
 				Params:          types.DefaultParams(),
 				TreasuryBalance: tt.args.treasuryBalance,
 			})
 			require.NoError(t, err)
 
-			got, err := app.DaoKeeper.Treasury(wctx, &types.QueryTreasuryRequest{})
-			require.NoError(t, err)
+			got := app.DaoKeeper.Treasury(ctx)
 			require.Equal(t, tt.want, got)
 		})
 	}

--- a/x/dao/module.go
+++ b/x/dao/module.go
@@ -133,7 +133,7 @@ func (am AppModule) LegacyQuerierHandler(legacyQuerierCdc *codec.LegacyAmino) sd
 // RegisterServices registers a GRPC query service to respond to the
 // module-specific GRPC queries.
 func (am AppModule) RegisterServices(cfg module.Configurator) {
-	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
+	types.RegisterQueryServer(cfg.QueryServer(), keeper.NewQueryServer(am.keeper))
 }
 
 // RegisterInvariants registers the dao module's invariants.


### PR DESCRIPTION
The PR contains the refactoring of the query DAO server. Now it is extracted from the Keep into QueryService struct in order not to mix the transport and business logic layers.