### PR TITLE
DAO rebalance implementation

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -367,6 +367,7 @@ func New( // nolint:funlen // app new cosmos func
 		app.GetSubspace(daotypes.ModuleName),
 		&app.BankKeeper,
 		&app.AccountKeeper,
+		&app.StakingKeeper,
 	)
 
 	// register the staking hooks
@@ -437,7 +438,7 @@ func New( // nolint:funlen // app new cosmos func
 		evidencetypes.ModuleName, stakingtypes.ModuleName, ibchost.ModuleName, feegrant.ModuleName,
 	)
 	app.mm.SetOrderEndBlockers(
-		crisistypes.ModuleName, govtypes.ModuleName, stakingtypes.ModuleName, gravitytypes.ModuleName,
+		crisistypes.ModuleName, govtypes.ModuleName, daotypes.ModuleName, stakingtypes.ModuleName, gravitytypes.ModuleName,
 	)
 
 	// NOTE: The genutils module must occur after staking so that pools are

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/cosmos/cosmos-sdk v0.44.5
 	github.com/cosmos/ibc-go/v2 v2.0.2
+	github.com/ethereum/go-ethereum v1.10.10
 	github.com/gogo/protobuf v1.3.3
 	github.com/golang/protobuf v1.5.2
 	github.com/google/go-cmp v0.5.7 // indirect

--- a/testutil/network/network.go
+++ b/testutil/network/network.go
@@ -31,18 +31,18 @@ type TestNetwork struct {
 	*network.Network
 }
 
-// ConfigOption is an option pattern function used fot the test network customisations.
-type ConfigOption func(*network.Config)
+// Option is an option pattern function used fot the test network customisations.
+type Option func(*network.Config)
 
-// WithGenesisOverride returns genesis override ConfigOption.
-func WithGenesisOverride(override func(map[string]json.RawMessage) map[string]json.RawMessage) ConfigOption {
+// WithGenesisOverride returns genesis override Option.
+func WithGenesisOverride(override func(map[string]json.RawMessage) map[string]json.RawMessage) Option {
 	return func(c *network.Config) {
 		c.GenesisState = override(c.GenesisState)
 	}
 }
 
 // New setups the test network.
-func New(t *testing.T, opts ...ConfigOption) *TestNetwork {
+func New(t *testing.T, opts ...Option) *TestNetwork {
 	t.Helper()
 
 	cfg := network.DefaultConfig()
@@ -51,7 +51,7 @@ func New(t *testing.T, opts ...ConfigOption) *TestNetwork {
 	encCfg := cosmoscmd.MakeEncodingConfig(app.ModuleBasics)
 	cfg.GenesisState = app.ModuleBasics.DefaultGenesis(encCfg.Marshaler)
 	cfg.AppConstructor = func(val network.Validator) servertypes.Application {
-		onomyApp := simapp.Setup(true)
+		onomyApp := simapp.Setup().OnomyApp()
 		// the override is required in order not to face the issue with the gravity end blocker validation
 		// because it requires the eth address to be linked with the validator account
 		onomyApp.SetOrderEndBlockers(crisistypes.ModuleName, govtypes.ModuleName, stakingtypes.ModuleName)

--- a/testutil/simapp/simapp.go
+++ b/testutil/simapp/simapp.go
@@ -2,19 +2,36 @@
 package simapp
 
 import (
+	"bytes"
 	"encoding/json"
+	"testing"
 
+	bam "github.com/cosmos/cosmos-sdk/baseapp"
+	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	"github.com/cosmos/cosmos-sdk/simapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
 	"github.com/tendermint/starport/starport/pkg/cosmoscmd"
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/log"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	dbm "github.com/tendermint/tm-db"
 
+	gravitytypes "github.com/onomyprotocol/cosmos-gravity-bridge/module/x/gravity/types"
 	"github.com/onomyprotocol/onomy/app"
 )
+
+// The SimApp is OnomyApp wrapper with the advance testing capabilities.
+type SimApp struct {
+	onomyApp *app.OnomyApp
+}
 
 // GenesisState of the blockchain is represented here as a map of raw json
 // messages key'd by a identifier string.
@@ -25,32 +42,173 @@ import (
 // object provided to it during init.
 type GenesisState map[string]json.RawMessage
 
+// Option is an option pattern function used fot the test simapp customisations.
+type Option struct {
+	before func(*SimApp, GenesisState) (*SimApp, GenesisState)
+	after  func(*SimApp) *SimApp
+}
+
+// WithGenesisAccountsAndBalances returns genesis override Option for initial balances.
+func WithGenesisAccountsAndBalances(balances ...banktypes.Balance) Option {
+	return Option{
+		before: func(simApp *SimApp, genState GenesisState) (*SimApp, GenesisState) {
+			accounts := make([]authtypes.GenesisAccount, 0, len(balances))
+			totalSupply := sdk.NewCoins()
+			for _, balance := range balances {
+				accounts = append(accounts, &authtypes.BaseAccount{
+					Address: balance.Address,
+				})
+				totalSupply = totalSupply.Add(balance.Coins...)
+			}
+
+			authGenesis := authtypes.NewGenesisState(authtypes.DefaultParams(), accounts)
+			genState[authtypes.ModuleName] = simApp.onomyApp.AppCodec().MustMarshalJSON(authGenesis)
+
+			s := totalSupply.String()
+			_ = s
+
+			bankGenesis := banktypes.NewGenesisState(banktypes.DefaultGenesisState().Params, balances, totalSupply, []banktypes.Metadata{})
+			genState[banktypes.ModuleName] = simApp.onomyApp.AppCodec().MustMarshalJSON(bankGenesis)
+
+			return simApp, genState
+		},
+	}
+}
+
+// WithGenesisOverride returns genesis override ConfigOption.
+func WithGenesisOverride(override func(map[string]json.RawMessage) map[string]json.RawMessage) Option {
+	return Option{
+		before: func(simApp *SimApp, genState GenesisState) (*SimApp, GenesisState) {
+			genState = override(genState)
+			return simApp, genState
+		},
+	}
+}
+
+// WithAppCommit commits the app state after the initialisation.
+func WithAppCommit() Option {
+	return Option{
+		after: func(simApp *SimApp) *SimApp {
+			simApp.onomyApp.Commit()
+			return simApp
+		},
+	}
+}
+
 // NewDefaultGenesisState generates the default state for the application.
 func NewDefaultGenesisState(cdc codec.JSONCodec) GenesisState {
 	return app.ModuleBasics.DefaultGenesis(cdc)
 }
 
 // Setup initializes a new SimApp. A Nop logger is set in SimApp.
-func Setup(isCheckTx bool) *app.OnomyApp {
-	onomyApp, genesisState := setup(!isCheckTx, 5) // nolint:gomnd //test constant
-	if !isCheckTx {
-		// init chain must be called to stop deliverState from being nil
-		stateBytes, err := json.MarshalIndent(genesisState, "", " ")
-		if err != nil {
-			panic(err)
-		}
+func Setup(opts ...Option) *SimApp {
+	onomyApp, genesisState := setup(5) // nolint:gomnd //test constant
 
-		// Initialize the chain
-		onomyApp.InitChain(
-			abci.RequestInitChain{
-				Validators:      []abci.ValidatorUpdate{},
-				ConsensusParams: simapp.DefaultConsensusParams,
-				AppStateBytes:   stateBytes,
-			},
-		)
+	simApp := &SimApp{
+		onomyApp: onomyApp,
 	}
 
-	return onomyApp
+	for _, opt := range opts {
+		if opt.before != nil {
+			simApp, genesisState = opt.before(simApp, genesisState)
+		}
+	}
+
+	// init chain must be called to stop deliverState from being nil
+	stateBytes, err := json.MarshalIndent(genesisState, "", " ")
+	if err != nil {
+		panic(err)
+	}
+
+	// Initialize the chain
+	simApp.onomyApp.InitChain(
+		abci.RequestInitChain{
+			Validators:      []abci.ValidatorUpdate{},
+			ConsensusParams: simapp.DefaultConsensusParams,
+			AppStateBytes:   stateBytes,
+		},
+	)
+
+	for _, opt := range opts {
+		if opt.after != nil {
+			simApp = opt.after(simApp)
+		}
+	}
+
+	return simApp
+}
+
+// OnomyApp returns OnomyApp from the SimApp.
+func (s *SimApp) OnomyApp() *app.OnomyApp {
+	return s.onomyApp
+}
+
+// BeginNextBlock begins new SimApp block.
+func (s *SimApp) BeginNextBlock() {
+	s.beginNextBlock()
+}
+
+// NewContext returns empty sdk context for the SimApp.
+func (s *SimApp) NewContext() sdk.Context {
+	return s.newContext()
+}
+
+// NewNextContext creates next block sdk context for the SimApp.
+func (s *SimApp) NewNextContext() sdk.Context {
+	header := tmproto.Header{Height: s.onomyApp.LastBlockHeight() + 1}
+	return s.onomyApp.BaseApp.NewContext(false, header)
+}
+
+// CreateValidator creates the validator.
+func (s *SimApp) CreateValidator(
+	t *testing.T,
+	selfDelegation sdk.Coin,
+	description stakingtypes.Description,
+	commission stakingtypes.CommissionRates,
+	minSelfDelegation sdk.Int,
+	priv cryptotypes.PrivKey,
+) {
+	t.Helper()
+
+	address := sdk.AccAddress(priv.PubKey().Address())
+	valAddress := sdk.ValAddress(address)
+	messages := make([]sdk.Msg, 0)
+	createValidatorMsg, err := stakingtypes.NewMsgCreateValidator(
+		valAddress, ed25519.GenPrivKey().PubKey(), selfDelegation, description, commission, minSelfDelegation,
+	)
+	require.NoError(t, err)
+	messages = append(messages, createValidatorMsg)
+
+	setOrchestratorAddressMsg := &gravitytypes.MsgSetOrchestratorAddress{
+		Validator:    createValidatorMsg.ValidatorAddress,
+		Orchestrator: address.String(),
+		EthAddress:   gethcommon.BytesToAddress(bytes.Repeat([]byte{byte(1)}, 20)).String(), // nolint:gomnd // eth address
+	}
+
+	if selfDelegation.Amount.GTE(sdk.DefaultPowerReduction) {
+		messages = append(messages, setOrchestratorAddressMsg)
+	}
+
+	account := s.onomyApp.AccountKeeper.GetAccount(s.newContext(), address)
+	accountNum := account.GetAccountNumber()
+	accountSeq := account.GetSequence()
+
+	s.beginNextBlock()
+
+	header := tmproto.Header{Height: s.onomyApp.LastBlockHeight() + 1}
+	txGen := cosmoscmd.MakeEncodingConfig(app.ModuleBasics).TxConfig
+
+	_, _, err = signCheckDeliver(t, txGen, s.onomyApp.BaseApp, header, messages, "", []uint64{accountNum}, []uint64{accountSeq}, true, true, priv)
+
+	require.NoError(t, err)
+}
+
+func (s *SimApp) beginNextBlock() {
+	s.onomyApp.BeginBlock(abci.RequestBeginBlock{Header: tmproto.Header{Height: s.onomyApp.LastBlockHeight() + 1}})
+}
+
+func (s *SimApp) newContext() sdk.Context {
+	return s.onomyApp.BaseApp.NewContext(true, tmproto.Header{})
 }
 
 // GenAccount generates random account.
@@ -59,12 +217,18 @@ func GenAccount() sdk.AccAddress {
 	return sdk.AccAddress(pk.Address())
 }
 
-func setup(withGenesis bool, invCheckPeriod uint) (*app.OnomyApp, GenesisState) {
+func setup(invCheckPeriod uint) (*app.OnomyApp, GenesisState) {
 	db := dbm.NewMemDB()
 	encCdc := cosmoscmd.MakeEncodingConfig(app.ModuleBasics)
-	onomyApp := app.New(log.NewNopLogger(), db, nil, true, map[int64]bool{}, app.DefaultNodeHome, invCheckPeriod, encCdc, simapp.EmptyAppOptions{})
-	if withGenesis {
-		return onomyApp.(*app.OnomyApp), NewDefaultGenesisState(encCdc.Marshaler)
-	}
-	return onomyApp.(*app.OnomyApp), GenesisState{}
+	simApp := app.New(log.NewNopLogger(), db, nil, true, map[int64]bool{}, app.DefaultNodeHome, invCheckPeriod, encCdc, simapp.EmptyAppOptions{})
+	return simApp.(*app.OnomyApp), NewDefaultGenesisState(encCdc.Marshaler)
+}
+
+func signCheckDeliver(
+	t *testing.T, txCfg client.TxConfig, app *bam.BaseApp, header tmproto.Header, msgs []sdk.Msg,
+	chainID string, accNums, accSeqs []uint64, expSimPass, expPass bool, priv ...cryptotypes.PrivKey,
+) (sdk.GasInfo, *sdk.Result, error) {
+	t.Helper()
+
+	return simapp.SignCheckDeliver(t, txCfg, app, header, msgs, chainID, accNums, accSeqs, expSimPass, expPass, priv...)
 }

--- a/x/dao/abci.go
+++ b/x/dao/abci.go
@@ -1,0 +1,20 @@
+package dao
+
+import (
+	"time"
+
+	"github.com/cosmos/cosmos-sdk/telemetry"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/onomyprotocol/onomy/x/dao/keeper"
+	"github.com/onomyprotocol/onomy/x/dao/types"
+)
+
+// EndBlocker calls the dao re-balancing every block.
+func EndBlocker(ctx sdk.Context, k keeper.Keeper) {
+	defer telemetry.ModuleMeasureSince(types.ModuleName, time.Now(), telemetry.MetricKeyEndBlocker)
+
+	if err := k.ReBalanceDelegation(ctx); err != nil {
+		k.Logger(ctx).Error("re-balance delegation error handled in %s EndBlocker , %v", types.ModuleName, err)
+	}
+}

--- a/x/dao/abci_test.go
+++ b/x/dao/abci_test.go
@@ -1,0 +1,195 @@
+package dao_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onomyprotocol/onomy/testutil/simapp"
+	"github.com/onomyprotocol/onomy/x/dao"
+	"github.com/onomyprotocol/onomy/x/dao/types"
+)
+
+func TestEndBlocker(t *testing.T) {
+	fiftyPercents := sdk.NewDec(1).Quo(sdk.NewDec(2))
+	tenPercents := sdk.NewDec(1).Quo(sdk.NewDec(10))
+	genesisCoins := sdk.NewCoin(sdk.DefaultBondDenom, sdk.TokensFromConsensusPower(100, sdk.DefaultPowerReduction))
+	lowBondCoin := sdk.NewInt64Coin(sdk.DefaultBondDenom, 1000) // not enough for validator to be bonded
+	normalBondCoin := sdk.NewCoin(sdk.DefaultBondDenom, sdk.TokensFromConsensusPower(10, sdk.DefaultPowerReduction))
+
+	lowCommission := stakingtypes.NewCommissionRates(tenPercents, tenPercents, tenPercents)
+	highCommission := stakingtypes.NewCommissionRates(fiftyPercents, fiftyPercents, fiftyPercents)
+
+	type valReq struct {
+		selfBondCoin sdk.Coin
+		commission   stakingtypes.CommissionRates
+	}
+
+	type valAssertion struct {
+		bondStatus     stakingtypes.BondStatus
+		selfBondAmount sdk.Dec
+		daoBondAmount  sdk.Dec
+	}
+
+	type args struct {
+		vals         map[string]valReq
+		treasuryBond sdk.Coin
+	}
+
+	type wantAssertion struct {
+		vals         map[string]valAssertion
+		treasuryBond sdk.Coin
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want wantAssertion
+	}{
+		{
+			name: "positive",
+			args: args{
+				vals: map[string]valReq{
+					"val1": { // bonded
+						selfBondCoin: normalBondCoin,
+						commission:   lowCommission,
+					},
+					"val2": { // bonded
+						selfBondCoin: normalBondCoin,
+						commission:   lowCommission,
+					},
+					"val3": { // won't be bonded
+						selfBondCoin: lowBondCoin,
+						commission:   lowCommission,
+					},
+					"val4": { // bonded, but high commission to be staked
+						selfBondCoin: normalBondCoin,
+						commission:   highCommission,
+					},
+				},
+				treasuryBond: sdk.NewCoin(sdk.DefaultBondDenom, sdk.TokensFromConsensusPower(100, sdk.DefaultPowerReduction)),
+			},
+			want: wantAssertion{
+				vals: map[string]valAssertion{
+					"val1": {
+						bondStatus:     stakingtypes.Bonded,
+						selfBondAmount: normalBondCoin.Amount.ToDec(),
+						daoBondAmount:  sdk.TokensFromConsensusPower(95, sdk.DefaultPowerReduction).ToDec().Quo(sdk.NewDec(2)),
+					},
+					"val2": {
+						bondStatus:     stakingtypes.Bonded,
+						selfBondAmount: normalBondCoin.Amount.ToDec(),
+						daoBondAmount:  sdk.TokensFromConsensusPower(95, sdk.DefaultPowerReduction).ToDec().Quo(sdk.NewDec(2)),
+					},
+					"val3": {
+						bondStatus:     stakingtypes.Unbonded,
+						selfBondAmount: lowBondCoin.Amount.ToDec(),
+						daoBondAmount:  sdk.ZeroDec(),
+					},
+					"val4": {
+						bondStatus:     stakingtypes.Bonded,
+						selfBondAmount: normalBondCoin.Amount.ToDec(),
+						daoBondAmount:  sdk.ZeroDec(),
+					},
+				},
+				treasuryBond: sdk.NewCoin(sdk.DefaultBondDenom, sdk.TokensFromConsensusPower(5, sdk.DefaultPowerReduction)),
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			// prepare account genesis params
+			balances := make([]banktypes.Balance, 0, len(tt.args.vals))
+			privateKeys := make(map[string]*secp256k1.PrivKey, len(tt.args.vals))
+			for moniker := range tt.args.vals {
+				privateKey := secp256k1.GenPrivKey()
+				privateKeys[moniker] = privateKey
+				address := sdk.AccAddress(privateKey.PubKey().Address())
+				balances = append(balances, banktypes.Balance{
+					Address: address.String(),
+					Coins:   sdk.Coins{genesisCoins},
+				})
+			}
+			// treasury genesis
+			treasuryOverrideOpt := simapp.WithGenesisOverride(
+				func(m map[string]json.RawMessage) map[string]json.RawMessage {
+					daoGenesis := types.DefaultGenesis()
+					daoGenesis.TreasuryBalance = sdk.NewCoins(tt.args.treasuryBond)
+					daoGenesisString, err := json.Marshal(daoGenesis)
+					require.NoError(t, err)
+					m[types.ModuleName] = daoGenesisString
+					return m
+				})
+
+			simApp := simapp.Setup(
+				simapp.WithGenesisAccountsAndBalances(balances...),
+				treasuryOverrideOpt,
+				simapp.WithAppCommit(),
+			)
+
+			for moniker, val := range tt.args.vals {
+				description := stakingtypes.Description{Moniker: moniker}
+				simApp.CreateValidator(t, val.selfBondCoin, description, val.commission, sdk.OneInt(), privateKeys[moniker])
+			}
+
+			simApp.BeginNextBlock()
+			ctx := simApp.NewContext()
+			dao.EndBlocker(ctx, simApp.OnomyApp().DaoKeeper)
+
+			// the chain is running
+			// assertions
+
+			accountKeeper := simApp.OnomyApp().AccountKeeper
+			daoKeeper := simApp.OnomyApp().DaoKeeper
+			stakingKeeper := simApp.OnomyApp().StakingKeeper
+			daoAddress := accountKeeper.GetModuleAddress(types.ModuleName)
+
+			updatedValidators := stakingKeeper.GetAllValidators(ctx)
+			assert.Equal(t, len(tt.args.vals), len(updatedValidators))
+
+			for _, val := range updatedValidators {
+				delegations := stakingKeeper.GetValidatorDelegations(ctx, val.GetOperator())
+				assert.LessOrEqual(t, 1, len(delegations))
+
+				valAssert, ok := tt.want.vals[val.GetMoniker()]
+				assert.True(t, ok)
+				assert.Equal(t, valAssert.bondStatus, val.Status, val.GetMoniker())
+
+				for _, delegation := range delegations {
+					switch delegation.DelegatorAddress {
+					case daoAddress.String():
+						{
+							assert.Equal(t, valAssert.daoBondAmount, delegation.Shares)
+						}
+					case sdk.AccAddress(val.GetOperator()).String():
+						{
+							assert.Equal(t, valAssert.selfBondAmount, delegation.Shares)
+						}
+					default:
+						{
+							t.Errorf("unexpected delegation %+v, of val %q, address: %q", delegation, val.GetMoniker(), val.GetOperator().String())
+						}
+					}
+				}
+
+				treasuryBond := daoKeeper.Treasury(ctx).AmountOf(stakingKeeper.BondDenom(ctx)).ToDec()
+				assert.Equal(t, tt.want.treasuryBond.Amount.ToDec(), treasuryBond)
+
+				// TBD:
+				// check that sum of all coins in the staking and remaining are eq initial pool
+				// check that all staking queues are empty
+				// add tests with the unbonding -> bonding validator
+				// add tests with the treasury bond pool change
+				// add test with the redelegation
+				// add tests with decimals rounding
+			}
+		})
+	}
+}

--- a/x/dao/genesis_test.go
+++ b/x/dao/genesis_test.go
@@ -5,7 +5,6 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
-	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
 	"github.com/onomyprotocol/onomy/testutil/simapp"
 	"github.com/onomyprotocol/onomy/x/dao"
@@ -37,13 +36,13 @@ func TestInitGenesis(t *testing.T) {
 	}
 	for _, tt := range tests {
 		tt := tt
-		app := simapp.Setup(false)
-		ctx := app.BaseApp.NewContext(false, tmproto.Header{})
+		simApp := simapp.Setup()
+		ctx := simApp.NewContext()
 		t.Run(tt.name, func(t *testing.T) {
-			dao.InitGenesis(ctx, app.DaoKeeper, tt.args.genState)
-			exportedModuleBalance := app.BankKeeper.GetAllBalances(ctx, app.AccountKeeper.GetModuleAddress(types.ModuleName))
+			dao.InitGenesis(ctx, simApp.OnomyApp().DaoKeeper, tt.args.genState)
+			exportedModuleBalance := simApp.OnomyApp().BankKeeper.GetAllBalances(ctx, simApp.OnomyApp().AccountKeeper.GetModuleAddress(types.ModuleName))
 			require.Equal(t, tt.args.genState.TreasuryBalance, exportedModuleBalance)
-			require.Equal(t, tt.args.genState.Params, app.DaoKeeper.GetParams(ctx))
+			require.Equal(t, tt.args.genState.Params, simApp.OnomyApp().DaoKeeper.GetParams(ctx))
 		})
 	}
 }
@@ -73,11 +72,11 @@ func TestInitAndExportGenesis(t *testing.T) {
 	}
 	for _, tt := range tests {
 		tt := tt
-		app := simapp.Setup(false)
-		ctx := app.BaseApp.NewContext(false, tmproto.Header{})
+		simApp := simapp.Setup()
+		ctx := simApp.NewContext()
 		t.Run(tt.name, func(t *testing.T) {
-			dao.InitGenesis(ctx, app.DaoKeeper, tt.args.genState)
-			exportedGenesis := dao.ExportGenesis(ctx, app.DaoKeeper)
+			dao.InitGenesis(ctx, simApp.OnomyApp().DaoKeeper, tt.args.genState)
+			exportedGenesis := dao.ExportGenesis(ctx, simApp.OnomyApp().DaoKeeper)
 			require.Equal(t, &tt.args.genState, exportedGenesis)
 		})
 	}

--- a/x/dao/keeper/delegation.go
+++ b/x/dao/keeper/delegation.go
@@ -1,0 +1,169 @@
+package keeper
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+
+	"github.com/onomyprotocol/onomy/x/dao/types"
+)
+
+// ReBalanceDelegation re-balances the DAO staking among validators bases on the current validators self bond.
+func (k Keeper) ReBalanceDelegation(ctx sdk.Context) error {
+	vals := k.stakingKeeper.GetAllValidators(ctx)
+	targetDelegations := k.getTargetDelegationState(ctx, vals)
+	return k.reBalanceDaoStaking(ctx, vals, targetDelegations)
+}
+
+// getTargetDelegationState builds a map of the validators and the stake amount they should have now.
+// if the validator is not in the map, the DAO stake is zero.
+func (k Keeper) getTargetDelegationState(ctx sdk.Context, vals []stakingtypes.Validator) map[string]sdk.Dec {
+	maxStakingCommissionRate := k.StakingMaxCommissionRate(ctx)
+	valsSelfBonds := make(map[string]sdk.Dec) // the key is OperatorAddress
+	valsSelfBondsSupply := sdk.NewDec(0)
+	for _, val := range vals {
+		if !val.IsBonded() {
+			continue
+		}
+		if val.GetCommission().GT(maxStakingCommissionRate) {
+			continue
+		}
+
+		valOperator := val.GetOperator()
+		valAddr := sdk.AccAddress(valOperator)
+		selfDelegation := k.stakingKeeper.Delegation(ctx, valAddr, valOperator)
+		if selfDelegation != nil && !selfDelegation.GetShares().IsZero() {
+			valsSelfBonds[valOperator.String()] = selfDelegation.GetShares()
+			valsSelfBondsSupply = valsSelfBondsSupply.Add(selfDelegation.GetShares())
+		}
+	}
+
+	daoDelegationSupply := k.getDaoDelegationSupply(ctx)
+	daoBondDenomSupply := k.treasuryBondDenomAmount(ctx).ToDec().Add(daoDelegationSupply)
+
+	stakingTokenPoolRate := k.StakingTokenPoolRate(ctx)
+	daoBondDenomToDelegate := daoBondDenomSupply.Mul(sdk.OneDec().Sub(stakingTokenPoolRate))
+
+	targetDelegationState := make(map[string]sdk.Dec) // the key is OperatorAddress
+	for valAddr, selfDelegationAmount := range valsSelfBonds {
+		valDaoDelegationAmount := selfDelegationAmount.Quo(valsSelfBondsSupply).Mul(daoBondDenomToDelegate)
+		if !valDaoDelegationAmount.IsZero() {
+			targetDelegationState[valAddr] = valDaoDelegationAmount
+		}
+	}
+
+	return targetDelegationState
+}
+
+func (k Keeper) getDaoDelegationSupply(ctx sdk.Context) sdk.Dec {
+	daoAddr := k.accountKeeper.GetModuleAddress(types.ModuleName)
+	delegations := k.stakingKeeper.GetAllDelegatorDelegations(ctx, daoAddr)
+	totalStakingSupply := sdk.NewDec(0)
+	for _, delegation := range delegations {
+		totalStakingSupply = totalStakingSupply.Add(delegation.GetShares())
+	}
+
+	return totalStakingSupply
+}
+
+func (k Keeper) reBalanceDaoStaking(ctx sdk.Context, vals []stakingtypes.Validator, targetDaoStaking map[string]sdk.Dec) error {
+	daoAddr := k.accountKeeper.GetModuleAddress(types.ModuleName)
+	delegations := make(map[string]sdk.Int)
+	undelegations := make(map[string]sdk.Dec)
+	for _, val := range vals {
+		valAddr := val.GetOperator()
+		targetDaoDelegation, ok := targetDaoStaking[valAddr.String()]
+		delegation := k.stakingKeeper.Delegation(ctx, daoAddr, valAddr)
+		delegatedByDao := sdk.NewDec(0)
+		if delegation != nil {
+			delegatedByDao = delegation.GetShares()
+		}
+		// for the validators not in the target list the target amount is zero
+		if !ok {
+			targetDaoDelegation = sdk.NewDec(0)
+		}
+
+		delegationDelta := targetDaoDelegation.RoundInt().Sub(delegatedByDao.RoundInt())
+		if delegationDelta.IsZero() {
+			continue
+		}
+
+		if delegationDelta.IsNegative() {
+			undelegations[valAddr.String()] = delegatedByDao.RoundInt().Sub(targetDaoDelegation.RoundInt()).ToDec()
+			continue
+		}
+
+		delegations[valAddr.String()] = delegationDelta
+	}
+
+	err := undelegateValidators(ctx, vals, undelegations, k, daoAddr)
+	if err != nil {
+		return err
+	}
+
+	err2 := k.delegateValidators(ctx, vals, delegations, daoAddr)
+	if err2 != nil {
+		return err2
+	}
+
+	return nil
+}
+
+func undelegateValidators(ctx sdk.Context, vals []stakingtypes.Validator, undelegations map[string]sdk.Dec, k Keeper, daoAddr sdk.AccAddress) error {
+	for _, val := range vals {
+		undelegation, ok := undelegations[val.GetOperator().String()]
+		if !ok {
+			continue
+		}
+		if _, err := k.stakingKeeper.Undelegate(ctx, daoAddr, val.GetOperator(), undelegation); err != nil {
+			return err
+		}
+		if err := k.completeUnbonding(ctx, daoAddr, val.GetOperator()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// completeUnbinding completes the unbonding of all entries in the
+// retrieved unbonding delegation object or an error upon failure.
+func (k Keeper) completeUnbonding(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) error {
+	ubd, found := k.stakingKeeper.GetUnbondingDelegation(ctx, delAddr, valAddr)
+	if !found {
+		return stakingtypes.ErrNoUnbondingDelegation
+	}
+
+	bondDenom := k.stakingKeeper.BondDenom(ctx)
+	delegatorAddress, err := sdk.AccAddressFromBech32(ubd.DelegatorAddress)
+	if err != nil {
+		return err
+	}
+
+	// loop through all the entries and complete unbonding mature entries
+	for i := 0; i < len(ubd.Entries); i++ {
+		entry := ubd.Entries[i]
+		if !entry.Balance.IsZero() {
+			amt := sdk.NewCoin(bondDenom, entry.Balance)
+			if err := k.bankKeeper.UndelegateCoinsFromModuleToAccount(
+				ctx, stakingtypes.NotBondedPoolName, delegatorAddress, sdk.NewCoins(amt),
+			); err != nil {
+				return err
+			}
+		}
+	}
+
+	k.stakingKeeper.RemoveUnbondingDelegation(ctx, ubd)
+	return nil
+}
+
+func (k Keeper) delegateValidators(ctx sdk.Context, vals []stakingtypes.Validator, delegations map[string]sdk.Int, daoAddr sdk.AccAddress) error {
+	for _, val := range vals {
+		delegation, ok := delegations[val.GetOperator().String()]
+		if !ok {
+			continue
+		}
+		if _, err := k.stakingKeeper.Delegate(ctx, daoAddr, delegation, stakingtypes.Unbonded, val, true); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/x/dao/keeper/genesis.go
+++ b/x/dao/keeper/genesis.go
@@ -16,12 +16,8 @@ func (k Keeper) InitGenesis(ctx sdk.Context, genState types.GenesisState) error 
 
 // ExportGenesis returns a GenesisState for a given context and keeper.
 func (k Keeper) ExportGenesis(ctx sdk.Context) *types.GenesisState {
-	params := k.GetParams(ctx)
-
-	daoAddress := k.accountKeeper.GetModuleAddress(types.ModuleName)
-	daoBalance := k.bankKeeper.GetAllBalances(ctx, daoAddress)
 	return &types.GenesisState{
-		Params:          params,
-		TreasuryBalance: daoBalance,
+		Params:          k.getParams(ctx),
+		TreasuryBalance: k.treasury(ctx),
 	}
 }

--- a/x/dao/keeper/keeper.go
+++ b/x/dao/keeper/keeper.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	"github.com/tendermint/tendermint/libs/log"
 
 	"github.com/onomyprotocol/onomy/x/dao/types"
@@ -18,9 +17,10 @@ type (
 		cdc           codec.BinaryCodec
 		storeKey      sdk.StoreKey
 		memKey        sdk.StoreKey
-		ps            paramtypes.Subspace
+		ps            types.ParamSubspace
 		bankKeeper    types.BankKeeper
 		accountKeeper types.AccountKeeper
+		stakingKeeper types.StakingKeeper
 	}
 )
 
@@ -29,13 +29,19 @@ func NewKeeper(
 	cdc codec.BinaryCodec,
 	storeKey,
 	memKey sdk.StoreKey,
-	ps paramtypes.Subspace,
+	ps types.ParamSubspace,
 	bankKeeper types.BankKeeper,
 	accountKeeper types.AccountKeeper,
+	stakingKeeper types.StakingKeeper,
 ) *Keeper {
 	// set KeyTable if it has not already been set
 	if !ps.HasKeyTable() {
 		ps = ps.WithKeyTable(types.ParamKeyTable())
+	}
+
+	// ensure dao module account is set
+	if addr := accountKeeper.GetModuleAddress(types.ModuleName); addr == nil {
+		panic(fmt.Sprintf("%s module account has not been set", types.ModuleName))
 	}
 
 	return &Keeper{
@@ -45,6 +51,7 @@ func NewKeeper(
 		ps:            ps,
 		bankKeeper:    bankKeeper,
 		accountKeeper: accountKeeper,
+		stakingKeeper: stakingKeeper,
 	}
 }
 

--- a/x/dao/keeper/params.go
+++ b/x/dao/keeper/params.go
@@ -7,12 +7,28 @@ import (
 )
 
 // GetParams returns the total set of dao parameters.
-func (k Keeper) GetParams(ctx sdk.Context) (params types.Params) {
-	k.ps.GetParamSet(ctx, &params)
-	return params
+func (k Keeper) GetParams(ctx sdk.Context) types.Params {
+	return k.getParams(ctx)
 }
 
 // SetParams set the params.
 func (k Keeper) SetParams(ctx sdk.Context, params types.Params) {
 	k.ps.SetParamSet(ctx, &params)
+}
+
+// StakingTokenPoolRate - the rate of total dao's staking coins to keep unstaked.
+func (k Keeper) StakingTokenPoolRate(ctx sdk.Context) (res sdk.Dec) {
+	k.ps.Get(ctx, types.KeyStakingTokenPoolRate, &res)
+	return
+}
+
+// StakingMaxCommissionRate - the max validator's commission to be staked by the dao.
+func (k Keeper) StakingMaxCommissionRate(ctx sdk.Context) (res sdk.Dec) {
+	k.ps.Get(ctx, types.KeyStakingMaxCommissionRate, &res)
+	return
+}
+
+func (k Keeper) getParams(ctx sdk.Context) (params types.Params) {
+	k.ps.GetParamSet(ctx, &params)
+	return params
 }

--- a/x/dao/keeper/params_test.go
+++ b/x/dao/keeper/params_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
 	"github.com/onomyprotocol/onomy/testutil/simapp"
 	"github.com/onomyprotocol/onomy/x/dao/types"
@@ -29,11 +28,11 @@ func TestKeeper_GetAndSetParams(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			app := simapp.Setup(false)
-			ctx := app.BaseApp.NewContext(false, tmproto.Header{})
+			simApp := simapp.Setup()
+			ctx := simApp.NewContext()
 
-			app.DaoKeeper.SetParams(ctx, tt.args.params)
-			got := app.DaoKeeper.GetParams(ctx)
+			simApp.OnomyApp().DaoKeeper.SetParams(ctx, tt.args.params)
+			got := simApp.OnomyApp().DaoKeeper.GetParams(ctx)
 
 			require.Equal(t, tt.args.params, got)
 		})

--- a/x/dao/keeper/proposal_test.go
+++ b/x/dao/keeper/proposal_test.go
@@ -6,7 +6,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/stretchr/testify/require"
-	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
 	"github.com/onomyprotocol/onomy/testutil/simapp"
 	"github.com/onomyprotocol/onomy/x/dao/types"
@@ -81,15 +80,15 @@ func TestKeeper_FundTreasuryProposal(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			app := simapp.Setup(false)
-			ctx := app.BaseApp.NewContext(false, tmproto.Header{})
-			require.NoError(t, app.BankKeeper.MintCoins(ctx, types.ModuleName, tt.args.accountBalance))
+			simApp := simapp.Setup()
+			ctx := simApp.NewContext()
+			require.NoError(t, simApp.OnomyApp().BankKeeper.MintCoins(ctx, types.ModuleName, tt.args.accountBalance))
 
 			senderAddr, err := sdk.AccAddressFromBech32(tt.args.sender)
 			require.NoError(t, err)
-			require.NoError(t, app.BankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, senderAddr, tt.args.accountBalance))
+			require.NoError(t, simApp.OnomyApp().BankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, senderAddr, tt.args.accountBalance))
 
-			err = app.DaoKeeper.FundTreasuryProposal(ctx, &types.FundTreasuryProposal{
+			err = simApp.OnomyApp().DaoKeeper.FundTreasuryProposal(ctx, &types.FundTreasuryProposal{
 				Sender: tt.args.sender,
 				Amount: tt.args.amount,
 			})
@@ -101,7 +100,7 @@ func TestKeeper_FundTreasuryProposal(t *testing.T) {
 
 			require.NoError(t, err)
 
-			got := app.DaoKeeper.Treasury(ctx)
+			got := simApp.OnomyApp().DaoKeeper.Treasury(ctx)
 			require.Equal(t, tt.wantTreasuryBalance, got)
 		})
 	}
@@ -257,16 +256,16 @@ func TestKeeper_ExchangeWithTreasuryProposal(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			app := simapp.Setup(false)
-			ctx := app.BaseApp.NewContext(false, tmproto.Header{})
+			simApp := simapp.Setup()
+			ctx := simApp.NewContext()
 
-			require.NoError(t, app.BankKeeper.MintCoins(ctx, types.ModuleName, tt.args.treasuryBalance))
-			require.NoError(t, app.BankKeeper.MintCoins(ctx, types.ModuleName, tt.args.accountBalance))
+			require.NoError(t, simApp.OnomyApp().BankKeeper.MintCoins(ctx, types.ModuleName, tt.args.treasuryBalance))
+			require.NoError(t, simApp.OnomyApp().BankKeeper.MintCoins(ctx, types.ModuleName, tt.args.accountBalance))
 			senderAddr, err := sdk.AccAddressFromBech32(tt.args.sender)
 			require.NoError(t, err)
-			require.NoError(t, app.BankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, senderAddr, tt.args.accountBalance))
+			require.NoError(t, simApp.OnomyApp().BankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, senderAddr, tt.args.accountBalance))
 
-			err = app.DaoKeeper.ExchangeWithTreasuryProposal(ctx, &types.ExchangeWithTreasuryProposal{
+			err = simApp.OnomyApp().DaoKeeper.ExchangeWithTreasuryProposal(ctx, &types.ExchangeWithTreasuryProposal{
 				Sender:     tt.args.sender,
 				CoinsPairs: tt.args.coinsPairs,
 			})
@@ -276,10 +275,10 @@ func TestKeeper_ExchangeWithTreasuryProposal(t *testing.T) {
 				return
 			}
 
-			got := app.DaoKeeper.Treasury(ctx)
+			got := simApp.OnomyApp().DaoKeeper.Treasury(ctx)
 			require.Equal(t, tt.wantTreasuryBalance, got)
 
-			senderBalance := app.BankKeeper.GetAllBalances(ctx, senderAddr)
+			senderBalance := simApp.OnomyApp().BankKeeper.GetAllBalances(ctx, senderAddr)
 			require.Equal(t, tt.wantAccountBalance, senderBalance)
 		})
 	}
@@ -354,10 +353,10 @@ func TestKeeper_FundAccountProposal(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			app := simapp.Setup(false)
-			ctx := app.BaseApp.NewContext(false, tmproto.Header{})
-			require.NoError(t, app.BankKeeper.MintCoins(ctx, types.ModuleName, tt.args.treasuryBalance))
-			err := app.DaoKeeper.FundAccountProposal(ctx, &types.FundAccountProposal{
+			simApp := simapp.Setup()
+			ctx := simApp.NewContext()
+			require.NoError(t, simApp.OnomyApp().BankKeeper.MintCoins(ctx, types.ModuleName, tt.args.treasuryBalance))
+			err := simApp.OnomyApp().DaoKeeper.FundAccountProposal(ctx, &types.FundAccountProposal{
 				Recipient: tt.args.recipient,
 				Amount:    tt.args.amount,
 			})
@@ -371,7 +370,7 @@ func TestKeeper_FundAccountProposal(t *testing.T) {
 
 			recipientAddr, err := sdk.AccAddressFromBech32(tt.args.recipient)
 			require.NoError(t, err)
-			got := app.BankKeeper.GetAllBalances(ctx, recipientAddr)
+			got := simApp.OnomyApp().BankKeeper.GetAllBalances(ctx, recipientAddr)
 			require.Equal(t, tt.wantAccountBalance, got)
 		})
 	}

--- a/x/dao/keeper/treasury.go
+++ b/x/dao/keeper/treasury.go
@@ -8,6 +8,16 @@ import (
 
 // Treasury returns the treasury balance.
 func (k Keeper) Treasury(ctx sdk.Context) sdk.Coins {
+	return k.treasury(ctx)
+}
+
+func (k Keeper) treasuryBondDenomAmount(ctx sdk.Context) sdk.Int {
+	denom := k.stakingKeeper.BondDenom(ctx)
+	return k.treasury(ctx).AmountOf(denom)
+}
+
+// treasury returns the treasury balance.
+func (k Keeper) treasury(ctx sdk.Context) sdk.Coins {
 	daoAddress := k.accountKeeper.GetModuleAddress(types.ModuleName)
 	return k.bankKeeper.GetAllBalances(ctx, daoAddress)
 }

--- a/x/dao/keeper/treasury_test.go
+++ b/x/dao/keeper/treasury_test.go
@@ -37,16 +37,16 @@ func TestKeeper_Treasury(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			app := simapp.Setup(false)
-			ctx := app.BaseApp.NewContext(false, tmproto.Header{})
+			simApp := simapp.Setup()
+			ctx := simApp.OnomyApp().BaseApp.NewContext(false, tmproto.Header{})
 
-			err := app.DaoKeeper.InitGenesis(ctx, types.GenesisState{
+			err := simApp.OnomyApp().DaoKeeper.InitGenesis(ctx, types.GenesisState{
 				Params:          types.DefaultParams(),
 				TreasuryBalance: tt.args.treasuryBalance,
 			})
 			require.NoError(t, err)
 
-			got := app.DaoKeeper.Treasury(ctx)
+			got := simApp.OnomyApp().DaoKeeper.Treasury(ctx)
 			require.Equal(t, tt.want, got)
 		})
 	}

--- a/x/dao/module.go
+++ b/x/dao/module.go
@@ -165,6 +165,7 @@ func (am AppModule) BeginBlock(_ sdk.Context, _ abci.RequestBeginBlock) {}
 
 // EndBlock executes all ABCI EndBlock logic respective to the dao module. It
 // returns no validator updates.
-func (am AppModule) EndBlock(_ sdk.Context, _ abci.RequestEndBlock) []abci.ValidatorUpdate {
+func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.ValidatorUpdate {
+	EndBlocker(ctx, am.keeper)
 	return []abci.ValidatorUpdate{}
 }

--- a/x/dao/types/expected_keepers.go
+++ b/x/dao/types/expected_keepers.go
@@ -1,30 +1,45 @@
 package types
 
 import (
+	"time"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
 // ParamSubspace defines the expected Subspace interface.
 type ParamSubspace interface {
 	HasKeyTable() bool
-	WithKeyTable(table paramtypes.KeyTable) paramtypes.Subspace
-	Get(ctx sdk.Context, key []byte, ptr interface{})
-	GetParamSet(ctx sdk.Context, ps paramtypes.ParamSet)
-	SetParamSet(ctx sdk.Context, ps paramtypes.ParamSet)
+	WithKeyTable(paramtypes.KeyTable) paramtypes.Subspace
+	Get(sdk.Context, []byte, interface{})
+	GetParamSet(sdk.Context, paramtypes.ParamSet)
+	SetParamSet(sdk.Context, paramtypes.ParamSet)
 }
 
 // AccountKeeper defines the contract required for account APIs.
 type AccountKeeper interface {
-	GetModuleAddress(name string) sdk.AccAddress
+	GetModuleAddress(string) sdk.AccAddress
 }
 
-// BankKeeper defines the contract needed to be fulfilled for banking and supply
-// dependencies.
+// BankKeeper defines the contract needed to be fulfilled for banking and supply dependencies.
 type BankKeeper interface {
-	GetAllBalances(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins
-	SendCoinsFromModuleToAccount(ctx sdk.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
-	SendCoinsFromModuleToModule(ctx sdk.Context, senderModule, recipientModule string, amt sdk.Coins) error
-	SendCoinsFromAccountToModule(ctx sdk.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
-	MintCoins(ctx sdk.Context, name string, amt sdk.Coins) error
+	GetAllBalances(sdk.Context, sdk.AccAddress) sdk.Coins
+	SendCoinsFromModuleToAccount(sdk.Context, string, sdk.AccAddress, sdk.Coins) error
+	SendCoinsFromAccountToModule(sdk.Context, sdk.AccAddress, string, sdk.Coins) error
+	MintCoins(sdk.Context, string, sdk.Coins) error
+	UndelegateCoinsFromModuleToAccount(sdk.Context, string, sdk.AccAddress, sdk.Coins) error
+}
+
+// StakingKeeper expected staking keeper.
+type StakingKeeper interface {
+	BondDenom(sdk.Context) string
+	Delegate(sdk.Context, sdk.AccAddress, sdk.Int, stakingtypes.BondStatus, stakingtypes.Validator, bool) (sdk.Dec, error)
+	Delegation(sdk.Context, sdk.AccAddress, sdk.ValAddress) stakingtypes.DelegationI
+	GetAllValidators(sdk.Context) []stakingtypes.Validator
+	GetAllDelegatorDelegations(sdk.Context, sdk.AccAddress) []stakingtypes.Delegation
+	GetUnbondingDelegation(sdk.Context, sdk.AccAddress, sdk.ValAddress) (stakingtypes.UnbondingDelegation, bool)
+	RemoveUnbondingDelegation(sdk.Context, stakingtypes.UnbondingDelegation)
+	SetUnbondingDelegation(sdk.Context, stakingtypes.UnbondingDelegation)
+	Undelegate(sdk.Context, sdk.AccAddress, sdk.ValAddress, sdk.Dec) (time.Time, error)
 }


### PR DESCRIPTION
The rebalance mechanist rebalances the DAO staking among the validators based on the [delegation strategy](https://github.com/onomyprotocol/onomy/blob/dao/x/dao/spec/02_state_transitions.md#delegation). The rebalance is integrated with the EndBlocker, hence after the end of each block the DAO staking will be rebalanced, if the rebalancing is required.