### PR TITLE
Add v1.0.3.5 upgrade and update Onomy-SDK import

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -96,6 +96,7 @@ import (
 	v1_0_1 "github.com/onomyprotocol/onomy/app/upgrades/v1.0.1"
 	v1_0_3 "github.com/onomyprotocol/onomy/app/upgrades/v1.0.3"
 	v1_0_3_4 "github.com/onomyprotocol/onomy/app/upgrades/v1.0.3.4"
+	v1_0_3_5 "github.com/onomyprotocol/onomy/app/upgrades/v1.0.3.5"
 	"github.com/onomyprotocol/onomy/docs"
 	"github.com/onomyprotocol/onomy/x/dao"
 	daoclient "github.com/onomyprotocol/onomy/x/dao/client"
@@ -331,6 +332,7 @@ func New( // nolint:funlen // app new cosmos func
 	app.UpgradeKeeper.SetUpgradeHandler(v1_0_1.Name, v1_0_1.UpgradeHandler)
 	app.UpgradeKeeper.SetUpgradeHandler(v1_0_3.Name, v1_0_3.UpgradeHandler)
 	app.UpgradeKeeper.SetUpgradeHandler(v1_0_3_4.Name, v1_0_3_4.UpgradeHandler)
+	app.UpgradeKeeper.SetUpgradeHandler(v1_0_3_5.Name, v1_0_3_5.UpgradeHandler)
 
 	// Create IBC Keeper
 	app.IBCKeeper = ibckeeper.NewKeeper(

--- a/app/upgrades/readme.md
+++ b/app/upgrades/readme.md
@@ -7,4 +7,4 @@ This folder contains sub-folders for every chain upgrade.
 - v1.0.1 - IBC integration fix
 - v1.0.3 - Hyperinflation fix
 - v1.0.3.4 - OIP 6 Undelegate DAO from all validators
-
+- v1.0.3.5 - OIP 6 Patch Subtract DAO Treasury from Staking Supply

--- a/app/upgrades/v1.0.3.5/upgrade.go
+++ b/app/upgrades/v1.0.3.5/upgrade.go
@@ -1,0 +1,16 @@
+// Package v1_0_3_5 is contains chain upgrade of the corresponding version.
+package v1_0_3_5 //nolint:revive,stylecheck // app version
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+)
+
+// Name is migration name.
+const Name = "v1.0.3.5"
+
+// UpgradeHandler is an x/upgrade handler.
+func UpgradeHandler(_ sdk.Context, _ upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+	return vm, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 replace (
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
 	// v0.44.8-onomy
-	github.com/cosmos/cosmos-sdk => github.com/onomyprotocol/onomy-sdk v0.44.6-0.20230418124728-9c1be80b05bd
+	github.com/cosmos/cosmos-sdk => github.com/onomyprotocol/onomy-sdk v0.44.6-0.20230527201514-b355cbab8616
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 
 	github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4

--- a/go.sum
+++ b/go.sum
@@ -1147,8 +1147,8 @@ github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onomyprotocol/cosmos-gravity-bridge/module v0.0.0-20220606130009-db180e048abe h1:x1KNDxuEGiP3VL6j4wZbJaMkZnS3W9dnAe+bWhqiZZ4=
 github.com/onomyprotocol/cosmos-gravity-bridge/module v0.0.0-20220606130009-db180e048abe/go.mod h1:/QuD174Pl6krV5sCOvQoTQ1TfFk0H1Qiutj5UYP7jvI=
-github.com/onomyprotocol/onomy-sdk v0.44.6-0.20230418124728-9c1be80b05bd h1:eIbAGelIUcg6B/I/U50d/+AJOZPMJO3bmJY+5lnnjjw=
-github.com/onomyprotocol/onomy-sdk v0.44.6-0.20230418124728-9c1be80b05bd/go.mod h1:xkaQHdLk55zxd1C2sR6dKh53QVoBW0IWFsKv3nQKwtY=
+github.com/onomyprotocol/onomy-sdk v0.44.6-0.20230527201514-b355cbab8616 h1:FH6BNRyTliIM46PlegdkxHL/fpHVxCgEduGZtzOiqwk=
+github.com/onomyprotocol/onomy-sdk v0.44.6-0.20230527201514-b355cbab8616/go.mod h1:xkaQHdLk55zxd1C2sR6dKh53QVoBW0IWFsKv3nQKwtY=
 github.com/onomyprotocol/tm-load-test v0.9.1-0.20211101093435-b38e68e11c01 h1:+B99URBdjbxtLuKUCSdOpyZ+Q6OpXNvQPsjXGgSBPRo=
 github.com/onomyprotocol/tm-load-test v0.9.1-0.20211101093435-b38e68e11c01/go.mod h1:KRiRasq+MPZHPAFx5VPkdkvXZTNW62ePuMn0+B5mrig=
 github.com/onsi/ginkgo v0.0.0-20151202141238-7f8ab55aaf3b/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=


### PR DESCRIPTION
Upgrade: Total Supply for staking purposes no longer includes the DAO Treasury.