### PR TITLE
Fix relative path in node init scripts

### DIFF
--- a/deploy/scripts/init-mainnet-full-node.sh
+++ b/deploy/scripts/init-mainnet-full-node.sh
@@ -60,7 +60,7 @@ echo "Initializing chain"
 onomyd $ONOMY_CHAINID_FLAG init $ONOMY_NODE_NAME
 
 #copy genesis file
-cp -r ../genesis/genesis-mainnet-1.json $ONOMY_HOME_CONFIG/genesis.json
+cp -r "$(dirname "$0")"/../../genesis/mainnet/genesis-mainnet-1.json $ONOMY_HOME_CONFIG/genesis.json
 
 echo "Updating node config"
 

--- a/deploy/scripts/init-testnet-full-node.sh
+++ b/deploy/scripts/init-testnet-full-node.sh
@@ -60,7 +60,7 @@ echo "Initializing chain"
 onomyd $ONOMY_CHAINID_FLAG init $ONOMY_NODE_NAME
 
 #copy genesis file
-cp -r "$(dirname "$0")"/../../genesis/genesis-testnet-1.json $ONOMY_HOME_CONFIG/genesis.json
+cp -r "$(dirname "$0")"/../../genesis/testnet/genesis-testnet-1.json $ONOMY_HOME_CONFIG/genesis.json
 
 echo "Updating node config"
 

--- a/deploy/scripts/init-testnet-full-node.sh
+++ b/deploy/scripts/init-testnet-full-node.sh
@@ -60,7 +60,7 @@ echo "Initializing chain"
 onomyd $ONOMY_CHAINID_FLAG init $ONOMY_NODE_NAME
 
 #copy genesis file
-cp -r ../genesis/genesis-testnet-1.json $ONOMY_HOME_CONFIG/genesis.json
+cp -r "$(dirname "$0")"/../../genesis/genesis-testnet-1.json $ONOMY_HOME_CONFIG/genesis.json
 
 echo "Updating node config"
 


### PR DESCRIPTION
When running the script in `./deploy/scripts` directory, the relative path breaks.

This PR changes the path relative to the script instead.