### PR TITLE
Update go to 1.21 to get 'slices' package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/onomyprotocol/onomy
 
-go 1.19
+go 1.21
 
 require (
 	github.com/cosmos/cosmos-sdk v0.45.16-ics


### PR DESCRIPTION
66de4c1ed4d9326b67feed653aa976c010042951 adds a requirement for the "slices" package which is only in the standard library since go 1.21